### PR TITLE
Fix step kind detection when language is declared in file comment.

### DIFF
--- a/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Psi/GherkinFile.cs
+++ b/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Psi/GherkinFile.cs
@@ -9,14 +9,29 @@ namespace ReSharperPlugin.SpecflowRiderPlugin.Psi
 {
     public class GherkinFile : FileElementBase
     {
+        public class FileMetadata
+        {
+            public FileMetadata(string filename, string lang)
+            {
+                Filename = filename;
+                Lang = lang;
+            }
+
+            public string Filename { get; set; }
+            public string Lang { get; set; }
+        }
+
         public override NodeType NodeType => GherkinNodeTypes.FILE;
         public override PsiLanguageType Language => GherkinLanguage.Instance.NotNull();
 
-        public string FileName { get; }
+        private readonly FileMetadata _metadata;
 
-        public GherkinFile(string fileName)
+        public string FileName => _metadata.Filename;
+        public string Lang => _metadata.Lang;
+
+        public GherkinFile(FileMetadata metadata)
         {
-            FileName = fileName;
+            _metadata = metadata;
         }
 
         [CanBeNull]

--- a/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Psi/GherkinLanguageComment.cs
+++ b/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Psi/GherkinLanguageComment.cs
@@ -1,0 +1,12 @@
+namespace ReSharperPlugin.SpecflowRiderPlugin.Psi
+{
+    public class GherkinLanguageComment : GherkinElement
+    {
+        public string Lang { get; }
+
+        public GherkinLanguageComment(string lang) : base(GherkinNodeTypes.LANGUAGE_COMMENT)
+        {
+            Lang = lang;
+        }
+    }
+}

--- a/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Psi/GherkinLanguageService.cs
+++ b/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Psi/GherkinLanguageService.cs
@@ -38,7 +38,7 @@ namespace ReSharperPlugin.SpecflowRiderPlugin.Psi
 
         public override IParser CreateParser(ILexer lexer, IPsiModule module, IPsiSourceFile sourceFile)
         {
-            return new GherkinParser(lexer, sourceFile);
+            return new GherkinParser(lexer, sourceFile, _settingsProvider, _keywordProvider);
         }
 
         public override IEnumerable<ITypeDeclaration> FindTypeDeclarations(IFile file)

--- a/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Psi/GherkinNodeTypes.cs
+++ b/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Psi/GherkinNodeTypes.cs
@@ -23,6 +23,7 @@ namespace ReSharperPlugin.SpecflowRiderPlugin.Psi
         public static readonly GherkinNodeType TABLE_ROW = new GherkinTableRowNodeType("TABLE_ROW", NextId);
         public static readonly GherkinNodeType TABLE = new GherkinTableNodeType("TABLE", NextId);
         public static readonly GherkinNodeType RULE = new GherkinRuleNodeType("RULE", NextId);
+        public static readonly GherkinNodeType LANGUAGE_COMMENT = new GherkinLanguageCommentNodeType("LANGUAGE_COMMENT", NextId);
 
         private class GherkinFileNodeType : GherkinNodeType
         {
@@ -32,7 +33,7 @@ namespace ReSharperPlugin.SpecflowRiderPlugin.Psi
 
             public override CompositeElement Create(object userData)
             {
-                return new GherkinFile((string) userData);
+                return new GherkinFile((GherkinFile.FileMetadata) userData);
             }
         }
         
@@ -71,10 +72,15 @@ namespace ReSharperPlugin.SpecflowRiderPlugin.Psi
             }
         }
         
-        private class GherkinStepNodeType : GherkinNodeType<GherkinStep>
+        private class GherkinStepNodeType : GherkinNodeType
         {
             public GherkinStepNodeType(string name, int index) : base(name, index)
             {
+            }
+
+            public override CompositeElement Create(object userData)
+            {
+                return new GherkinStep((GherkinStepKind) userData);
             }
         }
         
@@ -133,6 +139,17 @@ namespace ReSharperPlugin.SpecflowRiderPlugin.Psi
             {
             }
         }
-        
+
+        private class GherkinLanguageCommentNodeType : GherkinNodeType
+        {
+            public GherkinLanguageCommentNodeType(string name, int index) : base(name, index)
+            {
+            }
+
+            public override CompositeElement Create(object userData)
+            {
+                return new GherkinLanguageComment(userData as string);
+            }
+        }
     }
 }

--- a/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Psi/GherkinStep.cs
+++ b/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Psi/GherkinStep.cs
@@ -1,20 +1,20 @@
 using System.Collections.Generic;
 using System.Text;
 using JetBrains.DocumentModel;
-using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
 using JetBrains.ReSharper.Psi.Tree;
-using ReSharperPlugin.SpecflowRiderPlugin.Caching.SpecflowJsonSettings;
 using ReSharperPlugin.SpecflowRiderPlugin.References;
 
 namespace ReSharperPlugin.SpecflowRiderPlugin.Psi
 {
     public class GherkinStep : GherkinElement
     {
+        public GherkinStepKind StepKind { get; }
         private SpecflowStepDeclarationReference _reference;
 
-        public GherkinStep() : base(GherkinNodeTypes.STEP)
+        public GherkinStep(GherkinStepKind stepKind) : base(GherkinNodeTypes.STEP)
         {
+            StepKind = stepKind;
         }
 
         protected override void PreInit()
@@ -25,37 +25,7 @@ namespace ReSharperPlugin.SpecflowRiderPlugin.Psi
 
         public GherkinStepKind GetStepKind()
         {
-            var stepKeyword = this.FindChild<GherkinToken>(o => o.NodeType == GherkinTokenTypes.STEP_KEYWORD);
-            if (stepKeyword == null) return GherkinStepKind.Unknown;
-
-            var psiServices = GetPsiServices();
-            var settings = psiServices.GetComponent<SpecflowSettingsProvider>();
-            var gherkinKeywordProvider = psiServices.GetComponent<ILanguageManager>().GetService<GherkinKeywordProvider>(Language);
-            var project = this.GetProject();
-            var specflowSettingsLanguage = settings.GetSettings(project).Language.Feature;
-
-            var gherkinStepKind = gherkinKeywordProvider.GetStepKind(specflowSettingsLanguage, stepKeyword.GetText());
-            if (gherkinStepKind == GherkinStepKind.And)
-            {
-                gherkinStepKind = GetPreviousGherkinStepKind();
-                if (gherkinStepKind == GherkinStepKind.Unknown)
-                    return GherkinStepKind.Given;
-            }
-
-            return gherkinStepKind;
-        }
-
-        private GherkinStepKind GetPreviousGherkinStepKind()
-        {
-            var node = PrevSibling;
-            while (node != null)
-            {
-                if (node is GherkinStep gherkinStep)
-                    return gherkinStep.GetStepKind();
-                node = node.PrevSibling;
-            }
-
-            return GherkinStepKind.Unknown;
+            return StepKind;
         }
 
         public string GetKeywordText()


### PR DESCRIPTION
- Step kind is now detected during parsing (GherkinParser) and stored inside
GherkinStep: No more complex code to compute this, it's already computed
- When parsing language, create a new node GherkinLanguageComment if we
need to access this later (syntax highlight ?, check language is known ?)
- Store language into GherkinFile for future use (Keyword completion)