### PR TITLE
Fix tests when run on Mono

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,5 @@ mono_crash*.json
 packages
 
 *.generated.cs
+*.generated.props
 /src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/Analytics/AppInsightsConfiguration.cs

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ ext {
     rdLibDirectory = {
         new File(intellij.ideaDependency.classes, "lib/rd")
     }
+    resharperHostLibDirectory = {
+        new File(intellij.ideaDependency.classes, "lib/ReSharperHost")
+    }
     aiKey = System.getenv('APPINSIGHTSINSTRUMENTATIONKEY')
 }
 
@@ -53,7 +56,23 @@ compileKotlin {
     kotlinOptions { jvmTarget = "1.8" }
 }
 
+task prepareCompileDotNet {
+    def generatedPropsFile = file("${rootDir}/src/dotnet/SdkProperties.generated.props")
+    outputs.files generatedPropsFile
+    doLast {
+        generatedPropsFile.text = """<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <PropertyGroup>
+        <ReSharperHostPath>${resharperHostLibDirectory()}</ReSharperHostPath>
+    </PropertyGroup>
+</Project>
+"""
+    }
+}
+
 task compileDotNet {
+    dependsOn prepareCompileDotNet
+
     doLast {
         def arguments = ["msbuild","/t:Restore;Rebuild","${DotnetSolution}","/p:Configuration=${BuildConfiguration}","/p:HostFullIdentifier=","/p:AssemblyVersion=${version}"]
         if (aiKey) arguments << "/p:AppInsightsInstrumentationKey=${aiKey}";

--- a/src/dotnet/Directory.Build.props
+++ b/src/dotnet/Directory.Build.props
@@ -15,10 +15,32 @@
   </PropertyGroup>
 
   <Import Project="Plugin.props" />
+  <Import Project="SdkProperties.generated.props" />
 
   <PropertyGroup>
     <WaveVersionBase>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1))</WaveVersionBase>
     <WaveVersion>$(WaveVersionBase).0.0$(SdkVersion.Substring(8))</WaveVersion>
   </PropertyGroup>
 
+  <!-- Running tests on a Mac requires PresentationCore/PresentationFramework, which isn't part of the standard Mono/netcore
+       distro. We need to copy them from the SDK. Note that the IsOsPlatform function requires msbuild 15.3+
+       Note that this works, even though JetTestProject is defined AFTER this file is imported, because properties and
+       imports are evaluated before ItemGroups -->
+  <ItemGroup Condition=" '$(JetTestProject)' == 'True' AND '$([MSBuild]::IsOsPlatform(OSX))' == 'True' ">
+    <JetContent Include="$(ReSharperHostPath)\NetCore\runtimes\unix\lib\netcoreapp3.0\PresentationFramework.dll">
+      <TargetPath>PresentationFramework.dll</TargetPath>
+    </JetContent>
+    <JetContent Include="$(ReSharperHostPath)\NetCore\runtimes\unix\lib\netcoreapp3.0\PresentationCore.dll">
+      <TargetPath>PresentationCore.dll</TargetPath>
+    </JetContent>
+  </ItemGroup>
+  <!-- This is untested -->
+  <ItemGroup Condition=" '$(JetTestProject)' == 'True' AND '$([MSBuild]::IsOsPlatform(Linux))' == 'True' ">
+    <JetContent Include="$(ReSharperHostPath)\NetCore\runtimes\unix\lib\netcoreapp3.0\PresentationFramework.dll">
+      <TargetPath>PresentationFramework.dll</TargetPath>
+    </JetContent>
+    <JetContent Include="$(ReSharperHostPath)\NetCore\runtimes\unix\lib\netcoreapp3.0\PresentationCore.dll">
+      <TargetPath>PresentationCore.dll</TargetPath>
+    </JetContent>
+  </ItemGroup>
 </Project>

--- a/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin.Tests/MonoTestingComponents.cs
+++ b/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin.Tests/MonoTestingComponents.cs
@@ -1,0 +1,20 @@
+using JetBrains.Application.Environment;
+using JetBrains.Application.FileSystemTracker;
+using JetBrains.Util;
+
+namespace ReSharperPlugin.SpecflowRiderPlugin.Tests
+{
+    // The Unix file system watcher appears to be much slower to initialise than Windows. It's enabled by default, and
+    // disabled/re-enabled at the start and end of each test. But re-enabling reinitialises the watchers, which is very
+    // slow on Mono - killing performance in tests. It also means we initialise the watchers at the end of a test only
+    // to dispose at the start of the next test, which is completely unnecessary.
+    [EnvironmentComponent]
+    public class MonoFileSystemTrackerDisabler
+    {
+        public MonoFileSystemTrackerDisabler(IFileSystemTracker fileSystemTracker)
+        {
+            if (PlatformUtil.IsRunningOnMono)
+                fileSystemTracker.Enabled = false;
+        }
+    }
+}

--- a/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin.Tests/TestEnvironment.cs
+++ b/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin.Tests/TestEnvironment.cs
@@ -1,8 +1,10 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using JetBrains.Application.BuildScript.Application.Zones;
 using JetBrains.ReSharper.TestFramework;
 using JetBrains.TestFramework;
 using JetBrains.TestFramework.Application.Zones;
+using JetBrains.Util;
 using NUnit.Framework;
 
 [assembly: Apartment(ApartmentState.STA)]
@@ -17,5 +19,14 @@ namespace ReSharperPlugin.SpecflowRiderPlugin.Tests
   [SetUpFixture]
   public class TestEnvironment : ExtensionTestEnvironmentAssembly<ISpecflowRiderPluginTestZone>
   {
+    static TestEnvironment()
+    {
+      if (PlatformUtil.IsRunningOnMono)
+      {
+        // Workaround for GacCacheController, which adds all Mono GAC paths to a dictionary, without checking for duplicates.
+        // I think the implementation of Dictionary.Add is different on different runtimes
+        Environment.SetEnvironmentVariable("MONO_GAC_PREFIX", "/whatever");
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR will fix tests when run on Mono. Only tested on Mac, not Linux.

- [x] Copy `PresentationFramework.dll` and `PresentationCore.dll` from the Rider SDK to the test output folder
- [x] Work around an issue with an exception thrown when running on Mono due to not checking for duplicates when looking at the GAC
- [x] Add a testing only component that disables `IFileSystemTracker` on Mono. This has a huge impact on performance as Mono makes this an expensive component to initialise, and it is reinitialised after every test