### PR TITLE
Fix plugin build layout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,10 +159,10 @@ prepareSandbox {
 
     dllFiles.forEach({ f ->
         def file = file(f)
-        from(file, { into "${intellij.pluginName}/dotnet" })
+        from(file, { into "${intellij.pluginName.get()}/dotnet" })
     })
     
-    into("${intellij.pluginName}/projectTemplates") {
+    into("${intellij.pluginName.get()}/projectTemplates") {
         from("projectTemplates")
     }
 

--- a/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/ProjectTemplateParameters/TargetFrameworkProviderParameter.cs
+++ b/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/ProjectTemplateParameters/TargetFrameworkProviderParameter.cs
@@ -27,7 +27,7 @@ namespace ReSharperPlugin.SpecflowRiderPlugin.ProjectTemplateParameters
                 
                 options.Add(new RdProjectTemplateGroupOption(
                     choice.Key,
-                    choice.Value.DisplayName ?? choice.Key,
+                    choice.Value.Description ?? choice.Key,
                     null, content));
             }
             return new RdProjectTemplateGroupParameter(Name,PresentableName, parameter.DefaultValue, Tooltip, options);

--- a/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/ProjectTemplateParameters/UnitTestProviderParameter.cs
+++ b/src/dotnet/ReSharperPlugin.SpecflowRiderPlugin/ProjectTemplateParameters/UnitTestProviderParameter.cs
@@ -31,7 +31,7 @@ namespace ReSharperPlugin.SpecflowRiderPlugin.ProjectTemplateParameters
                 
                 options.Add(new RdProjectTemplateGroupOption(
                     choice.Key,
-                    choice.Value.DisplayName ?? choice.Key,
+                    choice.Value.Description ?? choice.Key,
                     null, content));
             }
             return new RdProjectTemplateGroupParameter(Name,PresentableName, parameter.DefaultValue, Tooltip, options);


### PR DESCRIPTION
It turns out that the dotnet DLLs weren't bundled into the plugin because of gradle-intellij-plugin version update: check the contents of `build/idea-sandbox/plugins` directory. There should only be `specflowriderplugin`, but before this PR there was another directory.