### PR TITLE
Build against 2023.3-EAP7-SNAPSHOT

### DIFF
--- a/.idea/.idea.SpecflowRiderPlugin/.idea/runConfigurations/Rider__Windows_.xml
+++ b/.idea/.idea.SpecflowRiderPlugin/.idea/runConfigurations/Rider__Windows_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Rider (Windows)" type="RunNativeExe" factoryName="Native Executable">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/../../../../Windows/System32/cmd.exe" />
-    <option name="PROGRAM_PARAMETERS" value="/c gradlew.bat :runIde -x compileKotlin -x compileDotNet t -PBuildConfiguration=Debug" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/../../../../../Windows/System32/cmd.exe" />
+    <option name="PROGRAM_PARAMETERS" value="/c gradlew.bat :runIde -x compileKotlin -x compileDotNet tasks -PBuildConfiguration=Debug" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <envs>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.19.0
+### Added
+- Support for Rider 2023.3-EAP7-SNAPSHOT
+
 ## 1.18.0
 ### Added
 - Support for Rider 2023.2.3

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,8 @@ intellij {
     instrumentCode = false
     // TODO: add plugins
     // plugins = ["uml", "com.jetbrains.ChooseRuntime:1.0.9"]
+    
+    sameSinceUntilBuild = false
 }
 
 runIde {
@@ -139,6 +141,8 @@ patchPluginXml {
     changeNotes = changelogMatches.collect {
         it[1].replaceAll(/(?s)- /, "\u2022 ").replaceAll(/`/, "").replaceAll(/,/, "%2C").replaceAll(/;/, "%3B")
     }.take(1).join('')
+    
+    untilBuild="${UntilBuild}"
 }
 
 prepareSandbox {

--- a/build.gradle
+++ b/build.gradle
@@ -88,8 +88,8 @@ intellij {
     instrumentCode = false
     // TODO: add plugins
     // plugins = ["uml", "com.jetbrains.ChooseRuntime:1.0.9"]
-    
-    updateSinceUntilBuild = false
+
+    updateSinceUntilBuild = true
     sameSinceUntilBuild = false
 }
 
@@ -142,6 +142,8 @@ patchPluginXml {
     changeNotes = changelogMatches.collect {
         it[1].replaceAll(/(?s)- /, "\u2022 ").replaceAll(/`/, "").replaceAll(/,/, "%2C").replaceAll(/;/, "%3B")
     }.take(1).join('')
+    
+    untilBuild = provider {null} // removes until-build in plugin.xml
 }
 
 prepareSandbox {

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ intellij {
     // TODO: add plugins
     // plugins = ["uml", "com.jetbrains.ChooseRuntime:1.0.9"]
     
+    updateSinceUntilBuild = false
     sameSinceUntilBuild = false
 }
 
@@ -141,8 +142,6 @@ patchPluginXml {
     changeNotes = changelogMatches.collect {
         it[1].replaceAll(/(?s)- /, "\u2022 ").replaceAll(/`/, "").replaceAll(/,/, "%2C").replaceAll(/;/, "%3B")
     }.take(1).join('')
-    
-    untilBuild="${UntilBuild}"
 }
 
 prepareSandbox {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ BuildConfiguration=Release
 #    2019.2-EAP2-SNAPSHOT
 #    2019.2
 ProductVersion=2023.3-EAP7-SNAPSHOT
-UntilBuild=2023.*
 
 # Kotlin 1.4 will bundle the stdlib dependency by default, causing problems with the version bundled with the IDE
 # https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-rc-released/#stdlib-default

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ BuildConfiguration=Release
 #    2019.2-SNAPSHOT
 #    2019.2-EAP2-SNAPSHOT
 #    2019.2
-ProductVersion=2023.3-SNAPSHOT
+ProductVersion=2023.3-EAP7-SNAPSHOT
 UntilBuild=2023.*
 
 # Kotlin 1.4 will bundle the stdlib dependency by default, causing problems with the version bundled with the IDE

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,15 +7,15 @@ org.gradle.jvmargs=-Xmx2g
 DotnetPluginId=ReSharperPlugin.SpecflowRiderPlugin
 DotnetSolution=SpecflowRiderPlugin.sln
 RiderPluginId=specflowriderplugin
-PluginVersion=1.18.0
+PluginVersion=1.19.0
 
 BuildConfiguration=Release
-
 # Possible values:
 #    2019.2-SNAPSHOT
 #    2019.2-EAP2-SNAPSHOT
 #    2019.2
-ProductVersion=2023.2.3
+ProductVersion=2023.3-SNAPSHOT
+UntilBuild=2023.*
 
 # Kotlin 1.4 will bundle the stdlib dependency by default, causing problems with the version bundled with the IDE
 # https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-rc-released/#stdlib-default

--- a/src/rider/main/resources/META-INF/plugin.xml
+++ b/src/rider/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
   <name>SpecFlow for Rider</name>
   <version>_PLACEHOLDER_</version>
   <vendor url="https://specflow.org/">SpecFlow</vendor>
-  <idea-version since-build="_PLACEHOLDER_" until-build="_PLACEHOLDER_" />
+  <idea-version since-build="_PLACEHOLDER_" />`
   <depends>com.intellij.modules.rider</depends>
 
   <description>

--- a/src/rider/main/resources/META-INF/plugin.xml
+++ b/src/rider/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
   <name>SpecFlow for Rider</name>
   <version>_PLACEHOLDER_</version>
   <vendor url="https://specflow.org/">SpecFlow</vendor>
-  <idea-version since-build="_PLACEHOLDER_" />`
+  <idea-version since-build="_PLACEHOLDER_" />
   <depends>com.intellij.modules.rider</depends>
 
   <description>

--- a/src/rider/main/resources/META-INF/plugin.xml
+++ b/src/rider/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
   <name>SpecFlow for Rider</name>
   <version>_PLACEHOLDER_</version>
   <vendor url="https://specflow.org/">SpecFlow</vendor>
-  <idea-version since-build="_PLACEHOLDER_" until-build="*" />
+  <idea-version since-build="_PLACEHOLDER_" until-build="_PLACEHOLDER_" />
   <depends>com.intellij.modules.rider</depends>
 
   <description>


### PR DESCRIPTION
Build against 2023.3-EAP7-SNAPSHOT and properly set the target version to the 2023.* range of versions (any less restrictive does not work).